### PR TITLE
Fix label for TLX_AAT

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -8,7 +8,7 @@
   ]},
 { "hdr": "DA60", "cmd": {"22": "7028"}, "freq": 5,
   "signals": [
-    {"id": "TLX_AAT", "path": "Climate", "fmt": {"bix": 128, "len": 16, "max": 200, "min": -200, "unit": "celsius" }, "name": "Front right tire pressure"}
+    {"id": "TLX_AAT", "path": "Climate", "fmt": {"bix": 128, "len": 16, "max": 200, "min": -200, "unit": "celsius" }, "name": "Ambient Air Temperature"}
   ]}
 ]
 }


### PR DESCRIPTION
TLX_AAT's "name" field says "Front right tire pressure" but should change to Ambient Air Temperature